### PR TITLE
Improve Windows support.

### DIFF
--- a/goGuru.py
+++ b/goGuru.py
@@ -216,9 +216,11 @@ class GoGuruCommand(sublime_plugin.TextCommand):
         # add local package to guru scope
         if get_setting("use_current_package", True) :
             current_file_path = os.path.realpath(os.path.dirname(file_path))
-            GOPATH = os.path.realpath(cmd_env["GOPATH"]+"/src")+"/"
-            local_package = current_file_path.replace(GOPATH, "")
-            debug("current_file_path", current_file_path)
+            GOPATH = os.path.realpath(cmd_env["GOPATH"])
+            GOPATH = os.path.join(GOPATH,"src")
+            local_package = os.path.relpath(current_file_path, GOPATH)
+            if sublime.platform() == 'windows':
+                local_package = local_package.replace('\\', '/')
             debug("GOPATH", GOPATH)
             debug("local_package", local_package)
             guru_scope = guru_scope+','+local_package

--- a/goGuru.py
+++ b/goGuru.py
@@ -181,6 +181,8 @@ class GoGuruCommand(sublime_plugin.TextCommand):
         for char_offset, char in enumerate(chars):
             cb_map[char_offset] = byte_offset
             byte_offset += len(char.encode('utf-8'))
+            if char == '\n' and self.view.line_endings() == "Windows":
+                byte_offset += 1
         return cb_map
 
     def guru(self, end_offset, begin_offset=None, mode="describe", callback=None):


### PR DESCRIPTION
SublimeText does not seem to include the \r in its internal representation of files using Windows line endings. This behavior causes GoGuru to send the wrong position information to the guru command.

This PR adjusts the offsets accordingly.
