### PR TITLE
Mouse click navigation, whicherrs and code cleanups

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,13 +1,15 @@
 [
     { "keys": ["ctrl+shift+g"], "command": "go_guru"},
-    { "keys": ["ctrl+alt+shift+g"], "command": "go_guru_show_results"}
+    { "keys": ["ctrl+alt+shift+g"], "command": "go_guru_show_results"},
+    { "keys": ["ctrl+.+ctrl+g"], "command": "go_guru_goto_definition", "context": [{ "key": "selector", "operator": "equal", "operand": "source.go" }] },
 ]
 /*
-	You can also set a key binding for a specific mode by adding a "mode" arg, e.g.:
+    You can also set a key binding for a specific mode by adding a "mode" arg, e.g.:
     ...
     { "keys": ["ctrl+super+c"], "command": "go_guru", "args": {"mode": "callers"} },
     { "keys": ["ctrl+super+i"], "command": "go_guru", "args": {"mode": "implements"} },
     { "keys": ["ctrl+super+r"], "command": "go_guru", "args": {"mode": "referrers"} },
+    { "keys": ["ctrl+.+ctrl+g"], "command": "go_guru", "args": {"mode": "definition", output=false}},
     ...
 	please set this in your user keybinds, no here.
 */

--- a/Default (Linux).sublime-mousemap
+++ b/Default (Linux).sublime-mousemap
@@ -1,0 +1,12 @@
+[
+    {
+        "button": "button2",
+        "modifiers": ["ctrl"],
+        "press_command": "drag_select",
+        "command": "go_guru",
+        "args": {
+            "mode": "definition",
+            "output": false
+        },
+    },
+]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,6 +1,7 @@
 [
     { "keys": ["ctrl+shift+g"], "command": "go_guru"},
-    { "keys": ["ctrl+alt+shift+g"], "command": "go_guru_show_results"}
+    { "keys": ["ctrl+alt+shift+g"], "command": "go_guru_show_results"},
+    { "keys": ["ctrl+.+ctrl+g"], "command": "go_guru_goto_definition", "context": [{ "key": "selector", "operator": "equal", "operand": "source.go" }] },
 ]
 /*
 	You can also set a key binding for a specific mode by adding a "mode" arg, e.g.:
@@ -8,6 +9,8 @@
     { "keys": ["ctrl+super+c"], "command": "go_guru", "args": {"mode": "callers"} },
     { "keys": ["ctrl+super+i"], "command": "go_guru", "args": {"mode": "implements"} },
     { "keys": ["ctrl+super+r"], "command": "go_guru", "args": {"mode": "referrers"} },
+    { "keys": ["ctrl+.+ctrl+g"], "command": "go_guru", "args": {"mode": "definition", output=false}},
+
     ...
 	please set this in your user keybinds, no here.
 */

--- a/Default (OSX).sublime-mousemap
+++ b/Default (OSX).sublime-mousemap
@@ -1,0 +1,12 @@
+[
+    {
+        "button": "button2",
+        "modifiers": ["ctrl"],
+        "press_command": "drag_select",
+        "command": "go_guru",
+        "args": {
+            "mode": "definition",
+            "output": false
+        },
+    },
+]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,6 +1,7 @@
 [
     { "keys": ["ctrl+shift+g"], "command": "go_guru"},
-    { "keys": ["ctrl+alt+shift+g"], "command": "go_guru_show_results"}
+    { "keys": ["ctrl+alt+shift+g"], "command": "go_guru_show_results"},
+    { "keys": ["ctrl+.+ctrl+g"], "command": "go_guru_goto_definition", "context": [{ "key": "selector", "operator": "equal", "operand": "source.go" }] },
 ]
 /*
 	You can also set a key binding for a specific mode by adding a "mode" arg, e.g.:
@@ -8,6 +9,7 @@
     { "keys": ["ctrl+super+c"], "command": "go_guru", "args": {"mode": "callers"} },
     { "keys": ["ctrl+super+i"], "command": "go_guru", "args": {"mode": "implements"} },
     { "keys": ["ctrl+super+r"], "command": "go_guru", "args": {"mode": "referrers"} },
+    { "keys": ["ctrl+.+ctrl+g"], "command": "go_guru", "args": {"mode": "definition", output=false}},
     ...
 	please set this in your user keybinds, no here.
 */

--- a/Default (Windows).sublime-mousemap
+++ b/Default (Windows).sublime-mousemap
@@ -1,0 +1,12 @@
+[
+    {
+        "button": "button2",
+        "modifiers": ["ctrl"],
+        "press_command": "drag_select",
+        "command": "go_guru",
+        "args": {
+            "mode": "definition",
+            "output": false
+        },
+    },
+]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -86,6 +86,13 @@
         }
     },
     {
+        "caption": "GoGuru: whicherrs",
+        "command": "go_guru",
+        "args": {
+            "mode": "whicherrs"
+        }
+    },
+    {
         "caption": "GoGuru: referrers",
         "command": "go_guru",
         "args": {

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -107,13 +107,6 @@
         }
     },
     {
-        "caption": "GoGuru: callgraph",
-        "command": "go_guru",
-        "args": {
-            "mode": "callgraph"
-        }
-    },
-    {
         "caption": "GoGuru: Default Settings",
         "command": "open_file",
         "args": {

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -43,6 +43,14 @@
         }
     },
     {
+        "caption": "GoGuru: jump to definition",
+        "command": "go_guru",
+        "args": {
+            "output": false,
+            "mode": "definition"
+        }
+    },
+    {
         "caption": "GoGuru: describe",
         "command": "go_guru",
         "args": {
@@ -129,5 +137,5 @@
         "platform": "OSX"
         }
     },
-    
+
 ]

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ GoGuru is a Golang plugin for [SublimeText](http://www.sublimetext.com/) 3 that 
 
 Please report any issues or improvements here [https://github.com/alvarolm/GoGuru/issues](https://github.com/alvarolm/GoGuru/issues)
 
-based on previus work from [waigani](http://github.com/waigani/GoOracle).
+based on previous work from [waigani](http://github.com/waigani/GoOracle).
 
-the guru tool still is on developent,
+the guru tool still is on development,
 check out the plan, the official git repo and the code review if you want to keep up:
 * https://docs.google.com/document/d/1UErU12vR7jTedYvKHVNRzGPmXqdMASZ6PfE7B-p6sIg/edit#
 * https://go.googlesource.com/tools/+log/master/cmd/guru
@@ -37,6 +37,8 @@ Select, or place your cursor over, a symbol (function, variable, constant etc) a
 
 Select one of the modes and the output will be displayed in a new tab.
 **double click on the file name in the results to jump directly to it.**
+
+You also can hold the `ctrl` key and `right-click` on a symbol to jump right to the definition.
 
 Install
 -------
@@ -111,6 +113,7 @@ Default key binding:
 [
     { "keys": ["ctrl+shift+g"], "command": "go_guru"},
     { "keys": ["ctrl+alt+shift+g"], "command": "go_guru_show_results"},
+    { "keys": ["ctrl+.+ctrl+g"], "command": "go_guru_goto_definition", "context": [{ "key": "selector", "operator": "equal", "operand": "source.go" }] },
 ]
 ```
 
@@ -123,7 +126,25 @@ You can also set a key binding for a specific mode by adding a "mode" arg, e.g.:
     { "keys": ["ctrl+super+c"], "command": "go_guru", "args": {"mode": "callers"} },
     { "keys": ["ctrl+super+i"], "command": "go_guru", "args": {"mode": "implements"} },
     { "keys": ["ctrl+super+r"], "command": "go_guru", "args": {"mode": "referrers"} },
+    { "keys": ["ctrl+.+ctrl+g"], "command": "go_guru", "args": {"mode": "definition", output=false}},
     ...
+```
+
+Default mouse bindings:
+
+```javascript
+[
+    {
+        "button": "button2",
+        "modifiers": ["ctrl"],
+        "press_command": "drag_select",
+        "command": "go_guru",
+        "args": {
+            "mode": "definition",
+            "output": false
+        },
+    },
+]
 ```
 
 


### PR DESCRIPTION
- Mouse click on a symbol, navigates to its definition. The output is disabled when it is in this mode as it is not required. 
- bugfix: Adds _whicherrs_ which was left out by mistake.
- I have also cleaned up the code, sorry I am pep8 crazy!

Cheers,
Arsham