### PR TITLE
fix default keybindings

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,15 +1,15 @@
 [
     { "keys": ["ctrl+shift+g"], "command": "go_guru"},
     { "keys": ["ctrl+alt+shift+g"], "command": "go_guru_show_results"},
-    { "keys": ["ctrl+.+ctrl+g"], "command": "go_guru_goto_definition", "context": [{ "key": "selector", "operator": "equal", "operand": "source.go" }] },
-]
-/*
+    { "keys": ["ctrl+.", "ctrl+g"], "command": "go_guru_goto_definition", "context": [{ "key": "selector", "operator": "equal", "operand": "source.go" }] },
+    /*
     You can also set a key binding for a specific mode by adding a "mode" arg, e.g.:
     ...
     { "keys": ["ctrl+super+c"], "command": "go_guru", "args": {"mode": "callers"} },
     { "keys": ["ctrl+super+i"], "command": "go_guru", "args": {"mode": "implements"} },
     { "keys": ["ctrl+super+r"], "command": "go_guru", "args": {"mode": "referrers"} },
-    { "keys": ["ctrl+.+ctrl+g"], "command": "go_guru", "args": {"mode": "definition", output=false}},
+    { "keys": ["ctrl+.+ctrl+g"], "command": "go_guru", "args": {"mode": "definition", "output": false}},
     ...
-	please set this in your user keybinds, no here.
-*/
+    Please set this in your user keybindings, not here.
+    */
+]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,16 +1,15 @@
 [
     { "keys": ["ctrl+shift+g"], "command": "go_guru"},
     { "keys": ["ctrl+alt+shift+g"], "command": "go_guru_show_results"},
-    { "keys": ["ctrl+.+ctrl+g"], "command": "go_guru_goto_definition", "context": [{ "key": "selector", "operator": "equal", "operand": "source.go" }] },
-]
-/*
-	You can also set a key binding for a specific mode by adding a "mode" arg, e.g.:
+    { "keys": ["ctrl+.", "ctrl+g"], "command": "go_guru_goto_definition", "context": [{ "key": "selector", "operator": "equal", "operand": "source.go" }] },
+    /*
+    You can also set a key binding for a specific mode by adding a "mode" arg, e.g.:
     ...
     { "keys": ["ctrl+super+c"], "command": "go_guru", "args": {"mode": "callers"} },
     { "keys": ["ctrl+super+i"], "command": "go_guru", "args": {"mode": "implements"} },
     { "keys": ["ctrl+super+r"], "command": "go_guru", "args": {"mode": "referrers"} },
-    { "keys": ["ctrl+.+ctrl+g"], "command": "go_guru", "args": {"mode": "definition", output=false}},
-
+    { "keys": ["ctrl+.+ctrl+g"], "command": "go_guru", "args": {"mode": "definition", "output": false}},
     ...
-	please set this in your user keybinds, no here.
-*/
+    Please set this in your user keybindings, not here.
+    */
+]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,15 +1,15 @@
 [
     { "keys": ["ctrl+shift+g"], "command": "go_guru"},
     { "keys": ["ctrl+alt+shift+g"], "command": "go_guru_show_results"},
-    { "keys": ["ctrl+.+ctrl+g"], "command": "go_guru_goto_definition", "context": [{ "key": "selector", "operator": "equal", "operand": "source.go" }] },
-]
-/*
-	You can also set a key binding for a specific mode by adding a "mode" arg, e.g.:
+    { "keys": ["ctrl+.", "ctrl+g"], "command": "go_guru_goto_definition", "context": [{ "key": "selector", "operator": "equal", "operand": "source.go" }] },
+    /*
+    You can also set a key binding for a specific mode by adding a "mode" arg, e.g.:
     ...
     { "keys": ["ctrl+super+c"], "command": "go_guru", "args": {"mode": "callers"} },
     { "keys": ["ctrl+super+i"], "command": "go_guru", "args": {"mode": "implements"} },
     { "keys": ["ctrl+super+r"], "command": "go_guru", "args": {"mode": "referrers"} },
-    { "keys": ["ctrl+.+ctrl+g"], "command": "go_guru", "args": {"mode": "definition", output=false}},
+    { "keys": ["ctrl+.+ctrl+g"], "command": "go_guru", "args": {"mode": "definition", "output": false}},
     ...
-	please set this in your user keybinds, no here.
-*/
+    Please set this in your user keybindings, not here.
+    */
+]


### PR DESCRIPTION
Fixes issue #32. The "go_guru_goto_definition" keybinding did not work and broke Sublime's default behavior for the "ctrl+g" keybinding.